### PR TITLE
Adjust crpropa-data to data files used in CRPropa3

### DIFF
--- a/calc_electromagnetic.py
+++ b/calc_electromagnetic.py
@@ -83,7 +83,7 @@ def process(sigma, field, name):
 
     # tabulated energies, limit to energies where the interaction is possible
     Emin = getEmin(sigma, field)
-    E = np.logspace(10, 23, 261) * eV
+    E = np.logspace(9, 23, 281) * eV
     E = E[E > Emin]
 
     # -------------------------------------------
@@ -98,7 +98,7 @@ def process(sigma, field, name):
     # save
     fname = folder + '/rate_%s.txt' % field.name
     data = np.c_[np.log10(E / eV), rate]
-    fmt = '%.2f\t%.6g'
+    fmt = '%.2f\t%.9g'
     header = '%s interaction rates\nphoton field: %s\nlog10(E/eV), 1/lambda [1/Mpc]' % (name, field.info)
     np.savetxt(fname, data, fmt=fmt, header=header)
 
@@ -129,7 +129,7 @@ def process(sigma, field, name):
     data = np.r_[row0, data]  # prepend log10(s_kin/eV^2) as first row
 
     fname = folder + '/cdf_%s.txt' % field.name
-    fmt = '%.2f' + '\t%.6g' * np.shape(rate_save)[1]
+    fmt = '%.2f' + '\t%.9g' * np.shape(rate_save)[1]
     header = '%s cumulative differential rate\nphoton field: %s\nlog10(E/eV), d(1/lambda)/ds_kin [1/Mpc/eV^2] for log10(s_kin/eV^2) as given in first row' % (name, field.info)
     np.savetxt(fname, data, fmt=fmt, header=header)
 

--- a/calc_photodisintegration.py
+++ b/calc_photodisintegration.py
@@ -83,7 +83,7 @@ for field in fields:
     np.savetxt(
         folder + '/rate_%s.txt' % field.name,
         np.r_[np.c_[d1sum['Z'], d1sum['N'], R1], np.c_[d2sum['Z'], d2sum['N'], R2]],
-        fmt='%i\t%i' + '\t%g' * 201,
+        fmt='%i\t%i' + '\t%.9g' * 201,
         header='Photodisintegration by the %s\nZ, N, 1/lambda [1/Mpc] for log10(gamma) = 6-14 in 201 steps' % field.info)
 
     # Calculate branching ratios from exclusive interaction rates
@@ -101,7 +101,7 @@ for field in fields:
     np.savetxt(
         folder + '/branching_%s.txt' % field.name,
         np.r_[np.c_[d1exc['Z'], d1exc['N'], d1exc['ch'], B1], np.c_[d2exc['Z'], d2exc['N'], d2exc['ch'], B2]],
-        fmt='%i\t%i\t%06d' + '\t%g' * 201,
+        fmt='%i\t%i\t%06d' + '\t%.9g' * 201,
         header='Photo-disintegration with the %s\nZ, N, channel, branching ratio for log10(gamma) = 6-14 in 201 steps' % field.info)
 
 
@@ -127,5 +127,5 @@ for field in []:
     np.savetxt(
         'data/Photodisintegration/photon_emission_%s.txt' % field.name.split('_')[0],
         np.c_[d3exc['Z'], d3exc['N'], d3exc['Zd'], d3exc['Nd'], d3exc['Ephoton'] * 1e6, B3],
-        fmt='%i\t%i\t%i\t%i\t%g' + '\t%g' * 201,
+        fmt='%i\t%i\t%i\t%i\t%.9g' + '\t%.9g' * 201,
         header='Emission probabilities of photons with discrete energies via photo-disintegration with the %s\nZ, N, Z_daughter, N_daughter, Ephoton [eV], emission probability for log10(gamma) = 6-14 in 201 steps' % field.info)


### PR DESCRIPTION
I found some small differences in the files created by the current crpropa-data master and the files used in CRPropa. This PR removes some of the differences.

1) increased energy range used in calc_electromagnetic.py
2) increase precision in calc_electromagnetic.py and calc_photodisintegration.py