### PR TITLE
Improve tables for electromagnetic interactions

### DIFF
--- a/calc_electromagnetic.py
+++ b/calc_electromagnetic.py
@@ -15,10 +15,10 @@ def sigmaPP(s):
     """ Pair production cross section (Breit-Wheeler), see Lee 1996 """
     smin = 4 * me2
     if (s < smin):
-        return 0
-    else:
-        b = np.sqrt(1 - smin / s)
-        return sigmaThomson * 3 / 16 * (1 - b**2) * ((3 - b**4) * np.log((1 + b) / (1 - b)) - 2 * b * (2 - b**2))
+        return 0.
+
+    b = np.sqrt(1 - smin / s)
+    return sigmaThomson * 3 / 16 * (1 - b**2) * ((3 - b**4) * (np.log1p(b) - np.log1p(-b)) - 2 * b * (2 - b**2))
 
 
 def sigmaDPP(s):
@@ -26,8 +26,8 @@ def sigmaDPP(s):
     smin = 16 * me2
     if (s < smin):
         return 0
-    else:
-        return 6.45E-34 * (1 - smin / s)**6
+
+    return 6.45E-34 * (1 - smin / s)**6
 
 
 def sigmaICS(s):
@@ -35,12 +35,12 @@ def sigmaICS(s):
     smin = me2
     if (s < smin):  # numerically unstable close to smin
         return 0
-    else:
-        # note: formula unstable for (s - smin) / smin < 1E-5
-        b = (s - smin) / (s + smin)
-        A = 2 / b / (1 + b) * (2 + 2 * b - b**2 - 2 * b**3)
-        B = (2 - 3 * b**2 - b**3) / b**2 * np.log((1 + b) / (1 - b))
-        return sigmaThomson * 3 / 8 * smin / s / b * (A - B)
+
+    # note: formula unstable for (s - smin) / smin < 1E-5
+    b = (s - smin) / (s + smin)
+    A = 2 / b / (1 + b) * (2 + 2 * b - b**2 - 2 * b**3)
+    B = (2 - 3 * b**2 - b**3) / b**2 * (np.log1p(b) - np.log1p(-b))
+    return sigmaThomson * 3 / 8 * smin / s / b * (A - B)
 
 
 def sigmaTPP(s):
@@ -48,8 +48,8 @@ def sigmaTPP(s):
     beta = 28 / 9 * np.log(s / me2) - 218 / 27
     if beta < 0:
         return 0
-    else:
-        return sigmaThomson * 3 / 8 / np.pi * alpha * beta
+    
+    return sigmaThomson * 3 / 8 / np.pi * alpha * beta
 
 
 def getTabulatedXS(sigma, skin):

--- a/calc_electromagnetic.py
+++ b/calc_electromagnetic.py
@@ -5,9 +5,9 @@ import photonField
 import os
 
 
-eV = 1.60217657E-19  # [J]
-me2 = (510.998918E3 * eV)**2  # squared electron mass [J^2/c^4]
-sigmaThomson = 6.6524E-29  # Thomson cross section [m^2]
+eV = 1.60217657e-19  # [J]
+me2 = (510.998918e3 * eV) ** 2  # squared electron mass [J^2/c^4]
+sigmaThomson = 6.6524e-29  # Thomson cross section [m^2]
 alpha = 1 / 137.035999074  # fine structure constant
 
 
@@ -91,14 +91,14 @@ def process(sigma, field, name):
     # -------------------------------------------
     # tabulated values of s_kin = s - mc^2
     # Note: integration method (Romberg) requires 2^n + 1 log-spaced tabulation points
-    s_kin = np.logspace(0, 23, 2 ** 18 + 1) * eV**2
+    s_kin = np.logspace(4, 23, 2 ** 18 + 1) * eV**2
     xs = getTabulatedXS(sigma, s_kin)
     rate = interactionRate.calc_rate_s(s_kin, xs, E, field)
 
     # save
     fname = folder + '/rate_%s.txt' % field.name
     data = np.c_[np.log10(E / eV), rate]
-    fmt = '%.2f\t%5.4e'
+    fmt = '%.2f\t%8.7e'
     header = '%s interaction rates\nphoton field: %s\nlog10(E/eV), 1/lambda [1/Mpc]' % (name, field.info)
     np.savetxt(fname, data, fmt=fmt, header=header)
 
@@ -112,14 +112,14 @@ def process(sigma, field, name):
 
     # tabulated values of s_kin = s - mc^2, limit to relevant range
     # Note: use higher resolution and then downsample
-    skin = np.logspace(0, 23, 460000 + 1) * eV**2
+    skin = np.logspace(4, 23, 380000 + 1) * eV**2
     skin = skin[skin > skin_min]
 
     xs = getTabulatedXS(sigma, skin)
     rate = interactionRate.calc_rate_s(skin, xs, E, field, cdf=True)
 
     # downsample
-    skin_save = np.logspace(0, 23, 230 + 1) * eV**2
+    skin_save = np.logspace(4, 23, 190 + 1) * eV**2
     skin_save = skin_save[skin_save > skin_min]
     rate_save = np.array([np.interp(skin_save, skin, r) for r in rate])
 
@@ -129,7 +129,7 @@ def process(sigma, field, name):
     data = np.r_[row0, data]  # prepend log10(s_kin/eV^2) as first row
 
     fname = folder + '/cdf_%s.txt' % field.name
-    fmt = '%.2f' + '\t%.9g' * np.shape(rate_save)[1]
+    fmt = '%.2f' + '\t%6.5e' * np.shape(rate_save)[1]
     header = '%s cumulative differential rate\nphoton field: %s\nlog10(E/eV), d(1/lambda)/ds_kin [1/Mpc/eV^2] for log10(s_kin/eV^2) as given in first row' % (name, field.info)
     np.savetxt(fname, data, fmt=fmt, header=header)
 
@@ -150,6 +150,8 @@ fields = [
     photonField.URB_Fixsen11(),
     photonField.URB_Nitu21()
     ]
+
+fields = [photonField.CMB()]
 
 for field in fields:
     print(field.name)

--- a/calc_electromagnetic.py
+++ b/calc_electromagnetic.py
@@ -7,18 +7,18 @@ import os
 
 eV = 1.60217657E-19  # [J]
 me2 = (510.998918E3 * eV)**2  # squared electron mass [J^2/c^4]
-sigmaThompson = 6.6524E-29  # Thompson cross section [m^2]
+sigmaThomson = 6.6524E-29  # Thomson cross section [m^2]
 alpha = 1 / 137.035999074  # fine structure constant
 
 
 def sigmaPP(s):
-    """ Pair production cross section (Bethe-Heitler), see Lee 1996 """
+    """ Pair production cross section (Breit-Wheeler), see Lee 1996 """
     smin = 4 * me2
     if (s < smin):
         return 0
     else:
         b = np.sqrt(1 - smin / s)
-        return sigmaThompson * 3 / 16 * (1 - b**2) * ((3 - b**4) * np.log((1 + b) / (1 - b)) - 2 * b * (2 - b**2))
+        return sigmaThomson * 3 / 16 * (1 - b**2) * ((3 - b**4) * np.log((1 + b) / (1 - b)) - 2 * b * (2 - b**2))
 
 
 def sigmaDPP(s):
@@ -40,7 +40,7 @@ def sigmaICS(s):
         b = (s - smin) / (s + smin)
         A = 2 / b / (1 + b) * (2 + 2 * b - b**2 - 2 * b**3)
         B = (2 - 3 * b**2 - b**3) / b**2 * np.log((1 + b) / (1 - b))
-        return sigmaThompson * 3 / 8 * smin / s / b * (A - B)
+        return sigmaThomson * 3 / 8 * smin / s / b * (A - B)
 
 
 def sigmaTPP(s):
@@ -49,7 +49,7 @@ def sigmaTPP(s):
     if beta < 0:
         return 0
     else:
-        return sigmaThompson * 3 / 8 / np.pi * alpha * beta
+        return sigmaThomson * 3 / 8 / np.pi * alpha * beta
 
 
 def getTabulatedXS(sigma, skin):

--- a/calc_electromagnetic.py
+++ b/calc_electromagnetic.py
@@ -151,8 +151,6 @@ fields = [
     photonField.URB_Nitu21()
     ]
 
-fields = [photonField.CMB()]
-
 for field in fields:
     print(field.name)
     process(sigmaPP, field, 'EMPairProduction')

--- a/photonField.py
+++ b/photonField.py
@@ -28,7 +28,7 @@ class CMB:
         Comoving spectral number density dn/deps [1/m^3/J] at given photon energy eps [J] and redshift z.
         Multiply with (1+z)^3 for the physical number density.
         """
-        return 8*np.pi / c0**3 / h**3 * eps**2 / (np.exp(eps/(kB*T_CMB)) - 1)
+        return 8*np.pi / c0**3 / h**3 * eps**2 / np.expm1(eps / (kB * T_CMB)) 
 
     def getEmin(self, z=0):
         """Minimum effective photon energy in [J]"""
@@ -304,7 +304,7 @@ class URB_Fixsen11:
         eps = np.r_[eps]
         nu = eps / h
         T = T_CMB + 24.1 * np.power(nu / 3.1e8, -2.6)
-        I = 8. * np.pi / c0 ** 3 / h ** 3 * eps ** 2 / (np.exp(eps / (kB * T)) - 1.)
+        I = 8. * np.pi / c0 ** 3 / h ** 3 * eps ** 2 / (np.expm1(eps / (kB * T)))
         I[eps < self.getEmin()] = 0.
         I[eps > self.getEmax()] = 0.
         return I


### PR DESCRIPTION
This PR addresses part of [issue #334](https://github.com/CRPropa/CRPropa3/issues/334)

- A bug in the interaction rates due to bad integration for inverse Compton was fixed.
- The kinematic range of the tabulated data was extended: smin is now 1 instead of 1e6.
- Adequate functions for log/exp were introduced to improve numerical accuracy.

Now it takes much longer to generate the tables (~10-20 minutes for all EM interactions), but the accuracy of the results is assured. There might be a better trade-off (slightly larger integration steps), but I see no reason why not just wait for the generation of precise tables which is a one-time-only job.

