### PR TITLE
Interaction rate integration for center-of-mass energy

### DIFF
--- a/calc_electromagnetic.py
+++ b/calc_electromagnetic.py
@@ -4,7 +4,7 @@ import interactionRate
 import photonField
 import os
 import gitHelp as gh
-from scipy.integrate import quad
+
 
 eV = 1.60217657e-19  # [J]
 me2 = (510.998918e3 * eV) ** 2  # squared electron mass [J^2/c^4]

--- a/calc_electromagnetic.py
+++ b/calc_electromagnetic.py
@@ -153,22 +153,22 @@ def process(sigma, field, name):
 
 fields = [
     photonField.CMB(),
-    # photonField.EBL_Kneiske04(),
-    # photonField.EBL_Stecker05(),
-    # photonField.EBL_Franceschini08(),
-    # photonField.EBL_Finke10(),
-    # photonField.EBL_Dominguez11(),
-    # photonField.EBL_Gilmore12(),
-    # photonField.EBL_Stecker16('lower'),
-    # photonField.EBL_Stecker16('upper'),
-    # photonField.URB_Protheroe96(),
-    # photonField.URB_Fixsen11(),
-    # photonField.URB_Nitu21()
+    photonField.EBL_Kneiske04(),
+    photonField.EBL_Stecker05(),
+    photonField.EBL_Franceschini08(),
+    photonField.EBL_Finke10(),
+    photonField.EBL_Dominguez11(),
+    photonField.EBL_Gilmore12(),
+    photonField.EBL_Stecker16('lower'),
+    photonField.EBL_Stecker16('upper'),
+    photonField.URB_Protheroe96(),
+    photonField.URB_Fixsen11(),
+    photonField.URB_Nitu21()
     ]
 
 for field in fields:
     print(field.name)
-    # process(sigmaPP, field, 'EMPairProduction')
-    # process(sigmaDPP, field, 'EMDoublePairProduction')
-    # process(sigmaTPP, field, 'EMTripletPairProduction')
+    process(sigmaPP, field, 'EMPairProduction')
+    process(sigmaDPP, field, 'EMDoublePairProduction')
+    process(sigmaTPP, field, 'EMTripletPairProduction')
     process(sigmaICS, field, 'EMInverseComptonScattering')

--- a/interactionRate.py
+++ b/interactionRate.py
@@ -51,7 +51,7 @@ def calc_rate_s(s_kin, xs, E, field, z=0, cdf=False):
     """
 
     if cdf:
-        # precalculate the field integral if it not exisist and load it afterwards
+        # precalculate the field integral if it not exists and load it afterwards
         calculateDensityIntegral(field)
         file = "data/fieldDensity/" + field.name + ".txt"
         densityIntegral = np.loadtxt(file)
@@ -72,17 +72,13 @@ def calc_rate_s(s_kin, xs, E, field, z=0, cdf=False):
         return romb(y, dx=ds) / 2 / E * Mpc
 
 def calculateDensityIntegral(field):
-    """ Precalculate the integral over the density 
+    """ 
+        Precalculate the integral over the density 
         int_{Emin}^{Emax} n(eps) / eps^2  deps 
         and save as a file.
 
         field : photon background, see photonField.py
     """
-
-    # precalc the photon density integral 
-    Emax = field.getEmax()
-    Emin =  1e4 / 4 / 1e23 * eV # min(s_kin) / 4 / max(E_e)
-    alpha = np.logspace(np.log10(Emin), np.log10(Emax), 10000) # lower boundary of the integral.
 
     # check if file already exist
     folder = "data/fieldDensity/"
@@ -92,16 +88,22 @@ def calculateDensityIntegral(field):
     if os.path.isfile(file):
         return # file already existst no calculation necessary
 
+    # precalc the photon density integral 
+    Emax = field.getEmax()
+    Emin =  1e4 / 4 / 1e23 * eV # min(s_kin) / 4 / max(E_e)
+    alpha = np.logspace(np.log10(Emin), np.log10(Emax), 10000) # lower boundary of the integral.
+
     # calculate integral
     I_gamma = np.zeros_like(alpha)
     for i in range(len(alpha)):
         I_gamma[i] = quad(lambda E: field.getDensity(E) / E**2, a = alpha[i], b = Emax, full_output=1)[0]
 
     # save file
-    header = "# calculate integral n(e)/e^2 de from eMin to eMax, where eMax is the maximal photon energy of the background \n"
+    header = "# Integrated spectral photon density.\n" 
+    header += "# Integral n(e)/e^2 de from eMin to eMax, where eMax is the maximal photon energy of the background \n"
     try: 
         git_hash = gh.get_git_revision_hash()
-        header += "Produced with crpropa-data version: "+git_hash+"\n"
+        header += "# Produced with crpropa-data version: "+git_hash+"\n"
         header += "# eMin [eV]\tintegral\n"
     except:
         header += "# eMin [eV]\tintegral\n"

--- a/interactionRate.py
+++ b/interactionRate.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy.integrate import cumulative_trapezoid, romb, quad
+import os
 
 eV = 1.60217657e-19  # [J]
 Mpc = 3.08567758e22  # [m]
@@ -50,6 +51,8 @@ def calc_rate_s(s_kin, xs, E, field, z=0, cdf=False):
     """
 
     if cdf:
+        # precalculate the field integral if it not exisist and load it afterwards
+        calculateDensityIntegral(field)
         file = "data/fieldDensity/" + field.name + ".txt"
         densityIntegral = np.loadtxt(file)
 
@@ -67,6 +70,44 @@ def calc_rate_s(s_kin, xs, E, field, z=0, cdf=False):
         y = n * F / s_kin
         ds = mean_log_spacing(s_kin)
         return romb(y, dx=ds) / 2 / E * Mpc
+
+def calculateDensityIntegral(field):
+    """ Precalculate the integral over the density 
+        int_{Emin}^{Emax} n(eps) / eps^2  deps 
+        and save as a file.
+
+        field : photon background, see photonField.py
+    """
+
+    # precalc the photon density integral 
+    Emax = field.getEmax()
+    Emin =  1e4 / 4 / 1e23 * eV # min(s_kin) / 4 / max(E_e)
+    alpha = np.logspace(np.log10(Emin), np.log10(Emax), 10000) # lower boundary of the integral.
+
+    # check if file already exist
+    folder = "data/fieldDensity/"
+    if not os.path.isdir(folder):
+        os.makedirs(folder)
+    file = folder + field.name + ".txt"
+    if os.path.isfile(file):
+        return # file already existst no calculation necessary
+
+    # calculate integral
+    I_gamma = np.zeros_like(alpha)
+    for i in range(len(alpha)):
+        I_gamma[i] = quad(lambda E: field.getDensity(E) / E**2, a = alpha[i], b = Emax, full_output=1)[0]
+
+    # save file
+    header = "# calculate integral n(e)/e^2 de from eMin to eMax, where eMax is the maximal photon energy of the background \n"
+    try: 
+        git_hash = gh.get_git_revision_hash()
+        header += "Produced with crpropa-data version: "+git_hash+"\n"
+        header += "# eMin [eV]\tintegral\n"
+    except:
+        header += "# eMin [eV]\tintegral\n"
+    data = np.c_[alpha, I_gamma]
+    fmt = '%.4e\t%8.7e'
+    np.savetxt(file, data, fmt = fmt, header = header)
 
 
 def mean_log_spacing(x):

--- a/interactionRate.py
+++ b/interactionRate.py
@@ -1,7 +1,6 @@
 import numpy as np
 from scipy.integrate import cumulative_trapezoid, romb, quad
 
-
 eV = 1.60217657e-19  # [J]
 Mpc = 3.08567758e22  # [m]
 
@@ -51,20 +50,13 @@ def calc_rate_s(s_kin, xs, E, field, z=0, cdf=False):
     """
 
     if cdf:
-        # precalc the photon density integral 
-        Emax = field.getEmax()
-        Emin = min(s_kin) / 4 / max(E)
-        alpha = np.logspace(np.log10(Emin), np.log10(Emax), 10000)
-        def integrand(E):
-            return field.getDensity(E) / E**2
-        I_gamma = np.zeros_like(alpha)
-        for i in range(len(alpha)):
-            I_gamma[i] = quad(integrand, a = alpha[i], b = Emax)[0]
+        file = "data/fieldDensity/" + field.name + ".txt"
+        densityIntegral = np.loadtxt(file)
 
         # interpolate
         I = np.zeros((len(E), len(s_kin)))
         for j in range(len(E)):
-            I[j,:] = np.interp(s_kin/ 4 / E[j], alpha, I_gamma)
+            I[j,:] = np.interp(s_kin/ 4 / E[j], densityIntegral[:,0], densityIntegral[:,1])
 
         # calculate cdf
         y = np.array([xs * s_kin for i in range(len(E))]) * I

--- a/interactionRate.py
+++ b/interactionRate.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.integrate import cumtrapz, romb
+from scipy.integrate import cumulative_trapezoid, romb
 
 
 eV = 1.60217657e-19  # [J]
@@ -22,11 +22,11 @@ def calc_rate_eps(eps, xs, gamma, field, z=0, cdf=False):
         interaction rate 1/lambda(gamma) [1/Mpc] or
         cumulative differential rate d(1/lambda)/d(s_kin) [1/Mpc/J^2]
     """
-    F = cumtrapz(x=eps, y=eps * xs, initial=0)
+    F = cumulative_trapezoid(x=eps, y=eps * xs, initial=0)
     n = field.getDensity(np.outer(1. / (2 * gamma), eps), z)
     if cdf:
         y = n * F / eps**2
-        return cumtrapz(x=eps, y=y, initial=0) / np.expand_dims(gamma, -1) * Mpc
+        return cumulative_trapezoid(x=eps, y=y, initial=0) / np.expand_dims(gamma, -1) * Mpc
     else:
         y = n * F / eps
         dx = mean_log_spacing(eps)
@@ -49,11 +49,11 @@ def calc_rate_s(s_kin, xs, E, field, z=0, cdf=False):
         interaction rate 1/lambda(gamma) [1/Mpc] or
         cumulative differential rate d(1/lambda)/d(s_kin) [1/Mpc/J^2]
     """
-    F = cumtrapz(x=s_kin, y=s_kin * xs, initial=0)
+    F = cumulative_trapezoid(x=s_kin, y=s_kin * xs, initial=0)
     n = field.getDensity(np.outer(1. / (4 * E), s_kin), z)
     if cdf:
         y = n * F / s_kin**2
-        return cumtrapz(x=s_kin, y=y, initial=0) / 2 / np.expand_dims(E, -1) * Mpc
+        return cumulative_trapezoid(x=s_kin, y=y, initial=0) / 2 / np.expand_dims(E, -1) * Mpc
     else:
         y = n * F / s_kin
         ds = mean_log_spacing(s_kin)

--- a/interactionRate.py
+++ b/interactionRate.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.integrate import cumulative_trapezoid, romb
+from scipy.integrate import cumulative_trapezoid, romb, quad
 
 
 eV = 1.60217657e-19  # [J]


### PR DESCRIPTION
This PR aims to close the Issue [#334](https://github.com/CRPropa/CRPropa3/issues/334) reported in the CRPropa main repository but is related to the CRPropa data repository.  

In the issue it is shown that the secondary spectrum of the photons from the Inverse Compton Scattering are shifted towards higher energy. Alexander Korochkin (AK) showed this is due to an incorrect integration of the cumulative distribution function of the interaction rate calculated in (interactionRate.py line 56). The mathematics can be found in [#334](https://github.com/CRPropa/CRPropa3/issues/334). The total interaction rate is calculated correctly. Therefore the primary CR spectra are correct at least to first order.The bug war reported for the Inverse Compton Scattering (ICS) but could be tracked down to a routine that is used by more interaction modules (EMPairProduction, EMDoublePairProduction, EMTriplePairProduction, EMInverseComptonScattering)

With this PR we change the integration for the CDF to
![EQN_CDF](https://user-images.githubusercontent.com/32195256/176896021-b9730d79-62ce-42e7-b2c4-52cbfe109b30.png)
given for example in (Elmag Paper: arXiv:1106.5508). 
In this way the second integral does not depend on the kind of interaction but only on the photon field density. Therefore it will be pre-calculated and stored in the directory "data/fieldDensity/"

To check the implementation we compared our CDF with the old version and the calculations by AK [#334](https://github.com/CRPropa/CRPropa3/issues/334).
![cdf_total](https://user-images.githubusercontent.com/32195256/176896442-df309873-b175-4b71-b9b3-357c338adc32.png)

Note: small differences to the AK versions arise from different binning for the produced data files.
And the arising secondary spectra for a mono-energetic injection for the CMB. This can be compared to the peak energy derived by AK and Andrey Saveliev. 
![spectra_compare_total](https://user-images.githubusercontent.com/32195256/176897074-70586929-32c1-450c-91db-5f7006afbcc4.png)

Thanks to @lukasmerten for tracing back the bug and discussing the implementation.

Cheers, 
Julien 
