### PR TITLE
Small changes in calc_synchrotron.py

### DIFF
--- a/calc_synchrotron.py
+++ b/calc_synchrotron.py
@@ -24,9 +24,8 @@ def synchrotron_spectrum(xval):
     F = np.zeros(len(xval))
     for i, value in enumerate(xval):
         a = xval[i:]
-        F[i] = integrate.trapz(x = a, y = kv(5. / 3., a))
-    for i,value in enumerate(xval):
-        b = integrate.cumtrapz(x = xval, y = xval * F, initial = 0)
+        F[i] = integrate.trapezoid(x = a, y = kv(5. / 3., a))
+    b = integrate.cumulative_trapezoid(x = xval, y = xval * F, initial = 0)
     return b / b[-1]
 
 

--- a/calc_synchrotron.py
+++ b/calc_synchrotron.py
@@ -65,8 +65,7 @@ def plot(specFile, plotFile):
     y = data[:, 1]
 
     y = np.diff(y) / np.diff(x)
-    x = 10 ** ((np.log10(x[:-1]) + np.diff(np.log10(x))) / 2.)
-    # y = np.diff(y) / np.diff(data[])
+    x = 10 ** ((np.log10(x[:-1]) + np.log10(x[1:])) / 2.)
 
     import matplotlib.pyplot as plt
     plt.figure()

--- a/calc_synchrotron.py
+++ b/calc_synchrotron.py
@@ -9,7 +9,7 @@ def synchrotron_spectrum(xval):
     """
     Calculate cumulative synchrotron spectrum.
     Follows:
-      J.~D. Jackson, Classical Electrondynamics.
+      J.~D. Jackson, Classical Electrodynamics.
       Wiley, 3rd ed., p. 681, eq. 14.91
 
     F(x) = (\int_{x}^{\infinity} K_{5/3}(x') dx') 


### PR DESCRIPTION
Dear all,

we noticed just three small points, that do not affect the physics, in the script calc_synchrotron.py, that @lukasmerten, @JulienDoerner, Athy, Jan-Niklas, Samata and me discussed today and thought of opening a small PR:

1) The calculation of the synchrotron spectral-function can be optimized, by taking out an unnecessary loop.
2) Update of deprecated function-naming.
3) Fix in the definition of the bins, to plot as a test the pdf of the spectrum, after calculating the derivative of the tabulated cdf. With the corrected definition, the expected spectral slope of the powerlaw tail of 1/3 instead of 2/3 is gained (see e.g. Fouka Mourad and Ouichaoui Saad 2013 Res. Astron. Astrophys. 13 680, eq.12). This change only affects the plotting, the calculated spectrum has been correct before.

**Old plot**
![sync_legacy](https://github.com/CRPropa/CRPropa3-data/assets/32835331/10614bad-f407-44de-a20c-a5456ae701e2)
**Updated plot**
Compare Fouka Mourad and Ouichaoui Saad 2013 Res. Astron. Astrophys. 13 680 fig.5, (https://iopscience.iop.org/article/10.1088/1674-4527/13/6/007/pdf)
![sync](https://github.com/CRPropa/CRPropa3-data/assets/32835331/21c5be8d-412e-4d81-8870-3ea7fb44e0e1)

