### PR TITLE
Typo in the Stecker16 class -  frequency computation

### DIFF
--- a/photonField.py
+++ b/photonField.py
@@ -432,7 +432,7 @@ class EBL_Stecker16(EBL):
 
         d_t = d.T
         eps_eV = eps / eV # [eV]
-        nu = eps / c_light  # [Hz]
+        nu = eps / h_planck  # [Hz]
         self.photonDensity = []
         self.energy = []
         for i, dens in enumerate(d_t):


### PR DESCRIPTION
In the class `EBL_Stecker16` (Extragalactic background light model from Stecker et al. 2016), the frequency was calculated using $\nu = E / c$ instead of $\nu = E / h$ ($E$ is the energy, $c$ the speed of light, and $h$ the Planck's constant). I fixed the typo.

Before the correction, the photon density as a function of energy was $\sim 42$ orders of magnitude smaller than what it should be, as it can be seen in the plot below.

![photon_density_before](https://github.com/user-attachments/assets/caddcaac-8e1f-40d8-a34f-916e6c3f4f5d)

After the correction, the photon density increases to the expected range (in both plots, I included the Extragalactic background light model from Gilmore et al. 2012 for comparison).

![photon_density_after](https://github.com/user-attachments/assets/7aef1232-0b96-414a-b53c-cb98a401caba)

